### PR TITLE
Fix kicad-data.cabal so that it builds

### DIFF
--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -32,7 +32,7 @@ library
   -- other-extensions:
   build-depends:
       base >=4.4 && <4.9
-    , parsec >=3.1 && <3.2
+    , parsec >=3.1.6 && <3.2
     , parsec-numbers >= 0.1.0  && <0.2.0
     , lens-family >= 1.1 && <1.2
     , ieee754 >= 0.7.4 && <0.8

--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -28,7 +28,8 @@ library
     , Data.Kicad.SExpr.SExpr
     , Data.Kicad.SExpr.Parse
     , Data.Kicad.SExpr.Write
-  -- other-modules:
+  other-modules:
+      Data.Kicad.Util
   -- other-extensions:
   build-depends:
       base >=4.4 && <4.9


### PR DESCRIPTION
I attempted to build kicad-data, and I ran into a couple of problems:

First, building kicad-data from Hackage does not work, because `Data/Kicad/Util.hs` is missing from the tarball.  In order for it to be included, it needs to be listed in `kicad-data.cabal`.

Second, the lower bound for parsec is too loose, because `endOfLine` did not appear in parsec until version 3.1.6.

This pull request fixes both of these issues.  Thanks!