### PR TITLE
Cabal file fixes: relax upper bounds, ensure source files get added to tarball

### DIFF
--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -32,11 +32,11 @@ library
       Data.Kicad.Util
   -- other-extensions:
   build-depends:
-      base >=4.4 && <4.9
+      base >=4.4 && <4.10
     , parsec >=3.1.6 && <3.2
     , parsec-numbers >= 0.1.0  && <0.2.0
-    , lens-family >= 1.1 && <1.2
-    , ieee754 >= 0.7.4 && <0.8
+    , lens-family >= 1.1 && <1.3
+    , ieee754 >= 0.7.4 && <0.9
     , pretty-compact >= 1.0 && < 2
   -- hs-source-dirs:
   default-language:    Haskell2010
@@ -50,11 +50,11 @@ test-suite kicad-data-quickcheck
   main-is: Test.hs
 
   build-depends:
-      base >=4.4 && <4.9
+      base >=4.4 && <4.10
     , parsec >=3.1 && <3.2
     , parsec-numbers >= 0.1.0  && <0.2.0
-    , lens-family >= 1.1 && <1.2
-    , ieee754 >= 0.7.4 && <0.8
+    , lens-family >= 1.1 && <1.3
+    , ieee754 >= 0.7.4 && <0.9
     , QuickCheck >= 2
     , test-framework >= 0.8 && < 1
     , test-framework-quickcheck2 >= 0.3 && < 1

--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -48,6 +48,10 @@ test-suite kicad-data-quickcheck
   hs-source-dirs: tests
   default-language: Haskell2010
   main-is: Test.hs
+  other-modules:
+      PcbnewExpr
+      SExpr
+      Utils
 
   build-depends:
       base >=4.4 && <4.10

--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -10,7 +10,7 @@ bug-reports:   http://github.com/kasbah/haskell-kicad-data/issues
 copyright:     2014
 category:      Data
 build-type:    Simple
--- extra-source-files:
+extra-source-files: README.md
 cabal-version: >=1.10
 
 source-repository head

--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -12,6 +12,9 @@ category:      Data
 build-type:    Simple
 extra-source-files: README.md
 cabal-version: >=1.10
+description:
+            Parse and write <http://kicad-pcb.org/ KiCAD> data
+            (currently @.kicad_mod@ files only).
 
 source-repository head
   type: git


### PR DESCRIPTION
These are some additional fixes to the `kicad-data.cabal` file:

* Relax upper bound on `base`, to allow using GHC 8.0.2.

* Relax upper bounds on `ieee754` and `lens-family`, since newer versions of these packages are available.

* Add several modules to `other-modules` of `kicad-data-quickcheck`, so that they will get added to the tarball that gets uploaded to Hackage.

* Similarly, add `README.md` to `extra-source-files`, so it is included in the tarball, too.

* Add a `description` field.  (`cabal check` complains if it is missing.)