### PR TITLE
Relax upper bound on base, to support ghc 8.2.1

### DIFF
--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -35,7 +35,7 @@ library
       Data.Kicad.Util
   -- other-extensions:
   build-depends:
-      base >=4.4 && <4.10
+      base >=4.4 && <4.11
     , parsec >=3.1.6 && <3.2
     , parsec-numbers >= 0.1.0  && <0.2.0
     , lens-family >= 1.1 && <1.3
@@ -57,7 +57,7 @@ test-suite kicad-data-quickcheck
       Utils
 
   build-depends:
-      base >=4.4 && <4.10
+      base >=4.4 && <4.11
     , parsec >=3.1 && <3.2
     , parsec-numbers >= 0.1.0  && <0.2.0
     , lens-family >= 1.1 && <1.3


### PR DESCRIPTION
Allow base 4.10, so that it can be compiled with ghc 8.2.1.  This was the only change necessary to work with ghc 8.2.1.  Tested using the [nightly-2017-07-31](https://www.stackage.org/nightly-2017-07-31) resolver.