### PR TITLE
Simplify s-expression parser and pass source location onto Pcbnew parsing

### DIFF
--- a/Data/Kicad/PcbnewExpr.hs
+++ b/Data/Kicad/PcbnewExpr.hs
@@ -4,6 +4,7 @@ module Data.Kicad.PcbnewExpr
   PcbnewExpr(..)
 -- * Parse
 , parse
+, parseWithFilename
 , fromSExpr
 -- * Write
 , pretty

--- a/Data/Kicad/PcbnewExpr/Parse.hs
+++ b/Data/Kicad/PcbnewExpr/Parse.hs
@@ -1,5 +1,6 @@
 module Data.Kicad.PcbnewExpr.Parse
 ( parse
+, parseWithFilename
 , fromSExpr
 )
 where
@@ -10,15 +11,20 @@ import Data.List (intersperse)
 import Text.Read (readMaybe)
 import Text.Parsec.Pos (newPos)
 
-import Data.Kicad.SExpr hiding (parse)
-import qualified Data.Kicad.SExpr as SExpr (parse)
+import Data.Kicad.SExpr hiding (parse, parseWithFilename)
+import qualified Data.Kicad.SExpr as SExpr (parse, parseWithFilename)
 import Data.Kicad.PcbnewExpr.PcbnewExpr
 import Data.Kicad.Util (headOr)
 
-{-| Parse a 'PcbnewExpr' from a 'String'. Returns an 'String' with an error or
-   a 'PcbnewExpr'. -}
+{-| Parse a Pcbnew expression from a string. Returns an 'String' with an error
+ - or a 'PcbnewExpr'. -}
 parse :: String -> Either String PcbnewExpr
-parse = either Left fromSExpr . SExpr.parse
+parse = parseWithFilename ""
+
+{-| Parse a Pcbnew expression from a string giving a filename argument to be used in error strings. -}
+parseWithFilename :: String -> String -> Either String PcbnewExpr
+parseWithFilename filename =
+   either Left fromSExpr . SExpr.parseWithFilename filename
 
 {-| Interpret a 'SExpr' as a 'PcbnewExpr'. -}
 fromSExpr :: SExpr -> Either String PcbnewExpr

--- a/Data/Kicad/PcbnewExpr/Parse.hs
+++ b/Data/Kicad/PcbnewExpr/Parse.hs
@@ -24,75 +24,70 @@ parse = parseWithFilename ""
 {-| Parse a Pcbnew expression from a string giving a filename argument to be used in error strings. -}
 parseWithFilename :: String -> String -> Either String PcbnewExpr
 parseWithFilename filename =
-   either Left fromSExpr . SExpr.parseWithFilename filename
+    either Left fromSExpr . SExpr.parseWithFilename filename
 
 {-| Interpret a 'SExpr' as a 'PcbnewExpr'. -}
 fromSExpr :: SExpr -> Either String PcbnewExpr
-fromSExpr (List _ (Atom pos kw:sxs)) =
-    case go of
-        Left err   -> Left $ "Could not interpret '" ++ kw ++
-                        "' because:\n\t" ++ err
-        Right expr -> Right expr
-    where go = case kw of
-            "module"     -> PcbnewExprModule    <$> asPcbnewModule           sxs
-            "pad"        -> PcbnewExprItem      <$> asPcbnewPad              sxs
-            "fp_text"    -> PcbnewExprItem      <$> asPcbnewFpText           sxs
-            "fp_arc"     -> PcbnewExprItem      <$> asPcbnewFpArc            sxs
-            "fp_poly"    -> PcbnewExprItem      <$> asPcbnewFpPoly           sxs
-            "layer"      -> PcbnewExprAttribute <$> asPcbnewLayer            sxs
-            "at"         -> PcbnewExprAttribute <$> asPcbnewAt               sxs
-            "effects"    -> PcbnewExprAttribute <$> asPcbnewEffects          sxs
-            "font"       -> PcbnewExprAttribute <$> asPcbnewFont             sxs
-            "layers"     -> PcbnewExprAttribute <$> asPcbnewLayers           sxs
-            "pts"        -> PcbnewExprAttribute <$> asPcbnewPts              sxs
-            "xyz"        -> PcbnewExprAttribute <$> asPcbnewXyz              sxs
-            "model"      -> PcbnewExprAttribute <$> asPcbnewModel            sxs
-            "drill"      -> PcbnewExprAttribute <$> asPcbnewDrill            sxs
-            "size"       -> PcbnewExprAttribute <$> asXy PcbnewSize          sxs
-            "start"      -> PcbnewExprAttribute <$> asXy PcbnewStart         sxs
-            "end"        -> PcbnewExprAttribute <$> asXy PcbnewEnd           sxs
-            "center"     -> PcbnewExprAttribute <$> asXy PcbnewCenter        sxs
-            "rect_delta" -> PcbnewExprAttribute <$> asXy PcbnewRectDelta     sxs
-            "xy"         -> PcbnewExprAttribute <$> asXy PcbnewXy            sxs
-            "offset"     -> PcbnewExprAttribute <$> asXy PcbnewOffset        sxs
-            "scale"      -> PcbnewExprAttribute <$> asXyz PcbnewModelScale   sxs
-            "rotate"     -> PcbnewExprAttribute <$> asXyz PcbnewModelRotate  sxs
-            "descr"      -> PcbnewExprAttribute <$> asString PcbnewDescr     sxs
-            "tags"       -> PcbnewExprAttribute <$> asString PcbnewTags      sxs
-            "path"       -> PcbnewExprAttribute <$> asString PcbnewPath      sxs
-            "attr"       -> PcbnewExprAttribute <$> asString PcbnewAttr      sxs
-            "tedit"      -> PcbnewExprAttribute <$> asString PcbnewTedit     sxs
-            "angle"      -> PcbnewExprAttribute <$> asDouble PcbnewAngle     sxs
-            "thickness"  -> PcbnewExprAttribute <$> asDouble PcbnewThickness sxs
-            "width"      -> PcbnewExprAttribute <$> asDouble PcbnewWidth     sxs
-            "justify"    -> PcbnewExprAttribute <$> asPcbnewJustifyT         sxs
-            "thermal_gap"
-                -> PcbnewExprAttribute <$> asDouble PcbnewThermalGap sxs
-            "thermal_width"
-                -> PcbnewExprAttribute <$> asDouble PcbnewThermalWidth sxs
-            "solder_paste_margin_ratio"
-                -> PcbnewExprAttribute <$> asDouble PcbnewPasteMarginRatio sxs
-            "solder_paste_margin"
-                -> PcbnewExprAttribute <$> asDouble PcbnewPasteMargin sxs
-            "solder_mask_margin"
-                -> PcbnewExprAttribute <$> asDouble PcbnewMaskMargin sxs
-            "clearance"
-                -> PcbnewExprAttribute <$> asDouble PcbnewClearance sxs
-            "solder_paste_ratio"
-                -> PcbnewExprAttribute <$> asDouble PcbnewSolderPasteRatio sxs
-            "fp_line"
-                -> PcbnewExprItem <$> asFp defaultPcbnewFpLine sxs
-            "fp_circle"
-                -> PcbnewExprItem <$> asFp defaultPcbnewFpCircle sxs
-            "autoplace_cost180"
-                -> PcbnewExprAttribute <$> asInt PcbnewAutoplaceCost180 sxs
-            "autoplace_cost90"
-                -> PcbnewExprAttribute <$> asInt PcbnewAutoplaceCost90 sxs
-            "zone_connect"
-                -> PcbnewExprAttribute <$> asInt PcbnewZoneConnect sxs
-            "roundrect_rratio"
-                -> PcbnewExprAttribute <$> asDouble PcbnewRoundrectRratio sxs
-            _   -> Left $ "Unknown expression type '" ++ kw ++ "' in " ++ show pos
+fromSExpr (List _ (Atom pos kw:sxs)) = case kw of
+    "module"     -> PcbnewExprModule    <$> asPcbnewModule           sxs
+    "pad"        -> PcbnewExprItem      <$> asPcbnewPad              sxs
+    "fp_text"    -> PcbnewExprItem      <$> asPcbnewFpText           sxs
+    "fp_arc"     -> PcbnewExprItem      <$> asPcbnewFpArc            sxs
+    "fp_poly"    -> PcbnewExprItem      <$> asPcbnewFpPoly           sxs
+    "layer"      -> PcbnewExprAttribute <$> asPcbnewLayer            sxs
+    "at"         -> PcbnewExprAttribute <$> asPcbnewAt               sxs
+    "effects"    -> PcbnewExprAttribute <$> asPcbnewEffects          sxs
+    "font"       -> PcbnewExprAttribute <$> asPcbnewFont             sxs
+    "layers"     -> PcbnewExprAttribute <$> asPcbnewLayers           sxs
+    "pts"        -> PcbnewExprAttribute <$> asPcbnewPts              sxs
+    "xyz"        -> PcbnewExprAttribute <$> asPcbnewXyz              sxs
+    "model"      -> PcbnewExprAttribute <$> asPcbnewModel            sxs
+    "drill"      -> PcbnewExprAttribute <$> asPcbnewDrill            sxs
+    "size"       -> PcbnewExprAttribute <$> asXy PcbnewSize          sxs
+    "start"      -> PcbnewExprAttribute <$> asXy PcbnewStart         sxs
+    "end"        -> PcbnewExprAttribute <$> asXy PcbnewEnd           sxs
+    "center"     -> PcbnewExprAttribute <$> asXy PcbnewCenter        sxs
+    "rect_delta" -> PcbnewExprAttribute <$> asXy PcbnewRectDelta     sxs
+    "xy"         -> PcbnewExprAttribute <$> asXy PcbnewXy            sxs
+    "offset"     -> PcbnewExprAttribute <$> asXy PcbnewOffset        sxs
+    "scale"      -> PcbnewExprAttribute <$> asXyz PcbnewModelScale   sxs
+    "rotate"     -> PcbnewExprAttribute <$> asXyz PcbnewModelRotate  sxs
+    "descr"      -> PcbnewExprAttribute <$> asString PcbnewDescr     sxs
+    "tags"       -> PcbnewExprAttribute <$> asString PcbnewTags      sxs
+    "path"       -> PcbnewExprAttribute <$> asString PcbnewPath      sxs
+    "attr"       -> PcbnewExprAttribute <$> asString PcbnewAttr      sxs
+    "tedit"      -> PcbnewExprAttribute <$> asString PcbnewTedit     sxs
+    "angle"      -> PcbnewExprAttribute <$> asDouble PcbnewAngle     sxs
+    "thickness"  -> PcbnewExprAttribute <$> asDouble PcbnewThickness sxs
+    "width"      -> PcbnewExprAttribute <$> asDouble PcbnewWidth     sxs
+    "justify"    -> PcbnewExprAttribute <$> asPcbnewJustifyT         sxs
+    "thermal_gap"
+        -> PcbnewExprAttribute <$> asDouble PcbnewThermalGap sxs
+    "thermal_width"
+        -> PcbnewExprAttribute <$> asDouble PcbnewThermalWidth sxs
+    "solder_paste_margin_ratio"
+        -> PcbnewExprAttribute <$> asDouble PcbnewPasteMarginRatio sxs
+    "solder_paste_margin"
+        -> PcbnewExprAttribute <$> asDouble PcbnewPasteMargin sxs
+    "solder_mask_margin"
+        -> PcbnewExprAttribute <$> asDouble PcbnewMaskMargin sxs
+    "clearance"
+        -> PcbnewExprAttribute <$> asDouble PcbnewClearance sxs
+    "solder_paste_ratio"
+        -> PcbnewExprAttribute <$> asDouble PcbnewSolderPasteRatio sxs
+    "fp_line"
+        -> PcbnewExprItem <$> asFp defaultPcbnewFpLine sxs
+    "fp_circle"
+        -> PcbnewExprItem <$> asFp defaultPcbnewFpCircle sxs
+    "autoplace_cost180"
+        -> PcbnewExprAttribute <$> asInt PcbnewAutoplaceCost180 sxs
+    "autoplace_cost90"
+        -> PcbnewExprAttribute <$> asInt PcbnewAutoplaceCost90 sxs
+    "zone_connect"
+        -> PcbnewExprAttribute <$> asInt PcbnewZoneConnect sxs
+    "roundrect_rratio"
+        -> PcbnewExprAttribute <$> asDouble PcbnewRoundrectRratio sxs
+    _   -> Left $ "Error in " ++ (show pos) ++ ": unknown expression type '" ++ kw ++ "'"
 fromSExpr sx@(Atom _ s) = case s of
     "italic" -> Right $ PcbnewExprAttribute PcbnewItalic
     "hide"   -> Right $ PcbnewExprAttribute PcbnewHide
@@ -107,7 +102,7 @@ asPcbnewModule (Atom _ n:xs) =
     where
         interpretRest [] m = Right m
         interpretRest (sx:sxs) m = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewLayer layer)) ->
                 interpretRest sxs m {pcbnewModuleLayer = layer}
             Right (PcbnewExprItem item) ->
@@ -133,7 +128,7 @@ asPcbnewFpText (t:s:a:xs) = interpretType
             (Atom _ string) -> interpretAt fp_text {fpTextStr = string}
             _           -> expecting "string" s
         interpretAt fp_text = case fromSExpr a of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewAt at)) ->
                 interpretRest xs fp_text {itemAt = at}
             _ -> expecting "'at' expression (e.g. '(at 1.0 1.0)')" a
@@ -152,7 +147,7 @@ asPcbnewFpText (t:s:a:xs) = interpretType
             _ -> fp_text
         interpretRest [] fp_text = Right fp_text
         interpretRest (sx:sxs) fp_text = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewLayer layer)) ->
                 interpretRest sxs (fp_text {itemLayer = layer})
             Right (PcbnewExprAttribute (PcbnewFpTextEffects effects)) ->
@@ -166,20 +161,20 @@ asFp :: PcbnewItem -> [SExpr] -> Either String PcbnewItem
 asFp defaultFp (s:e:xs) = interpretStart defaultFp
     where
         interpretStart fp_shape = case fromSExpr s of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewStart start)) ->
                 interpretEnd fp_shape {itemStart = start}
             Right (PcbnewExprAttribute (PcbnewCenter center)) ->
                 interpretEnd fp_shape {itemStart = center}
             Right _ -> expecting "start (e.g. '(start 1.0 1.0)')" s
         interpretEnd fp_shape = case fromSExpr e of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewEnd end)) ->
                 interpretRest xs fp_shape {itemEnd = end}
             Right _ -> expecting "end (e.g. '(end 1.0 1.0)')" e
         interpretRest [] fp_shape = Right fp_shape
         interpretRest (sx:sxs) fp_shape = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewWidth d))
                 -> interpretRest sxs fp_shape {itemWidth = d}
             Right (PcbnewExprAttribute (PcbnewLayer d))
@@ -191,18 +186,18 @@ asPcbnewFpArc :: [SExpr] -> Either String PcbnewItem
 asPcbnewFpArc (s:e:xs) = interpretStart defaultPcbnewFpArc
     where
         interpretStart fp_arc = case fromSExpr s of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewStart start)) ->
                 interpretEnd fp_arc {itemStart = start}
             Right _ -> expecting "start (e.g. '(start 1.0 1.0)')" s
         interpretEnd fp_arc = case fromSExpr e of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewEnd end)) ->
                 interpretRest xs fp_arc {itemEnd = end}
             Right _ -> expecting "end (e.g. '(end 1.0 1.0)')" e
         interpretRest [] fp_arc = Right fp_arc
         interpretRest (sx:sxs) fp_arc = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewWidth d))
                 -> interpretRest sxs fp_arc {itemWidth = d}
             Right (PcbnewExprAttribute (PcbnewLayer d))
@@ -217,7 +212,7 @@ asPcbnewFpPoly xs = interpretRest xs defaultPcbnewFpPoly
     where
         interpretRest [] fp_poly = Right fp_poly
         interpretRest (sx:sxs) fp_poly = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewPts   d))
                 -> interpretRest sxs fp_poly {fpPolyPts = d}
             Right (PcbnewExprAttribute (PcbnewWidth d))
@@ -249,7 +244,7 @@ asPcbnewPad (n:t:s:xs) = interpretNumber
         interpretRest :: [SExpr] -> PcbnewItem -> Either String PcbnewItem
         interpretRest [] pad = Right pad
         interpretRest (sx:sxs) pad = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewAt d))
                 -> interpretRest sxs pad {itemAt = d}
             Right (PcbnewExprAttribute (PcbnewLayers d))
@@ -321,7 +316,7 @@ asPcbnewEffects xs = interpretRest xs []
    where
       interpretRest [] effects = Right (PcbnewFpTextEffects effects)
       interpretRest (sx:sxs) effects = case fromSExpr sx of
-         Left err -> Left ('\t':err)
+         Left err -> Left err
          Right (PcbnewExprAttribute justify@(PcbnewJustify _))
             -> interpretRest sxs (justify:effects)
          Right (PcbnewExprAttribute font@(PcbnewFont _ _ _))
@@ -334,7 +329,7 @@ asPcbnewFont xs = interpretRest xs defaultPcbnewFont
     where
         interpretRest [] font = Right font
         interpretRest (sx:sxs) font = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewSize size)) ->
                 interpretRest sxs font {pcbnewFontSize = size}
             Right (PcbnewExprAttribute (PcbnewThickness t)) ->
@@ -352,7 +347,7 @@ asXy _ x = expecting' "two floats (e.g. 1.0 1.0)" x
 asPcbnewPts :: [SExpr] -> Either String PcbnewAttribute
 asPcbnewPts = fmap PcbnewPts . foldr interpretXys (Right [])
     where interpretXys sx z = case fromSExpr sx of
-                        Left err -> Left ('\t':err)
+                        Left err -> Left err
                         Right (PcbnewExprAttribute (PcbnewXy xy))
                             -> Right (xy:) <*> z
                         Right _ -> expecting "'xy' (e.g. '(xy 1.0 1.0)')" sx
@@ -387,7 +382,7 @@ asPcbnewDrill xs = interpretRest xs defaultPcbnewDrillT
         interpretRest (sx:sxs) drill = case sx of
             Atom _ "oval"  -> interpretRest sxs drill {pcbnewDrillOval = True}
             (List _ _) -> case fromSExpr sx of
-                Left err -> Left ('\t':err)
+                Left err -> Left err
                 Right (PcbnewExprAttribute (PcbnewOffset xy))
                     -> interpretRest sxs drill {pcbnewDrillOffset = Just xy}
                 Right _ -> expecting "offset or nothing" sx
@@ -409,7 +404,7 @@ asPcbnewXyz x = expecting' "three floats" x
 
 asXyz :: (PcbnewAttribute -> a) -> [SExpr] -> Either String a
 asXyz constructor [l@(List _ _)] = case fromSExpr l of
-    Left err -> Left ('\t':err)
+    Left err -> Left err
     Right (PcbnewExprAttribute xyz) -> Right $ constructor xyz
     Right _ -> expecting "xyz (e.g. '(xyz 1 1 1)')" l
 asXyz _ x = expecting' "xyz (e.g. '(xyz 1 1 1)')" x
@@ -419,7 +414,7 @@ asPcbnewModel (Atom _ p:xs) = interpretRest xs defaultPcbnewModel {pcbnewModelPa
     where
         interpretRest [] model = Right model
         interpretRest (sx:sxs) model = case fromSExpr sx of
-            Left err -> Left ('\t':err)
+            Left err -> Left err
             Right (PcbnewExprAttribute (PcbnewModelAt (PcbnewXyz xyz))) ->
                 interpretRest sxs model {pcbnewModelAt = xyz}
             Right (PcbnewExprAttribute (PcbnewModelScale (PcbnewXyz xyz))) ->
@@ -451,8 +446,8 @@ oneJustifyT x = expecting justifyOneOf x
 
 expecting :: String -> SExpr -> Either String a
 expecting x y =
-    Left $ "Expecting " ++ x ++ " but got " ++
-        nothing_or (strip_brackets (write y)) ++ " instead in " ++ pos
+    Left $ "Error in " ++ pos ++ ": expecting " ++ x ++ " but got " ++
+        nothing_or (strip_brackets (write y)) ++ " instead"
     where
         nothing_or y' = case y' of
             "" -> "nothing"

--- a/Data/Kicad/PcbnewExpr/Parse.hs
+++ b/Data/Kicad/PcbnewExpr/Parse.hs
@@ -8,6 +8,7 @@ import Data.Maybe
 import Lens.Family2 (over)
 import Data.List (intersperse)
 import Text.Read (readMaybe)
+import Text.Parsec.Pos (newPos)
 
 import Data.Kicad.SExpr hiding (parse)
 import qualified Data.Kicad.SExpr as SExpr (parse)
@@ -21,7 +22,7 @@ parse = either Left fromSExpr . SExpr.parse
 
 {-| Interpret a 'SExpr' as a 'PcbnewExpr'. -}
 fromSExpr :: SExpr -> Either String PcbnewExpr
-fromSExpr (List (Atom kw:sxs)) =
+fromSExpr (List posList (Atom pos kw:sxs)) =
     case go of
         Left err   -> Left $ "Could not interpret '" ++ kw ++
                         "' because:\n\t" ++ err
@@ -85,17 +86,17 @@ fromSExpr (List (Atom kw:sxs)) =
                 -> PcbnewExprAttribute <$> asInt PcbnewZoneConnect sxs
             "roundrect_rratio"
                 -> PcbnewExprAttribute <$> asDouble PcbnewRoundrectRratio sxs
-            _   -> Left $ "Unknown expression type '" ++ kw ++ "'"
-fromSExpr sx@(Atom s) = case s of
+            _   -> Left $ "Unknown expression type '" ++ kw ++ "' in " ++ show pos
+fromSExpr sx@(Atom pos s) = case s of
     "italic" -> Right $ PcbnewExprAttribute PcbnewItalic
     "hide"   -> Right $ PcbnewExprAttribute PcbnewHide
     "locked" -> Right $ PcbnewExprAttribute PcbnewLocked
     "placed" -> Right $ PcbnewExprAttribute PcbnewPlaced
     _ -> expecting "'italic' or 'hide' or 'locked' " sx
-fromSExpr x = expecting "List with a key or a string atom" x
+fromSExpr x = expecting "List pos with a key or a string atom" x
 
 asPcbnewModule :: [SExpr] -> Either String PcbnewModule
-asPcbnewModule (Atom n:xs) =
+asPcbnewModule (Atom pos n:xs) =
     interpretRest xs defaultPcbnewModule { pcbnewModuleName = n }
     where
         interpretRest [] m = Right m
@@ -115,15 +116,15 @@ asPcbnewFpText :: [SExpr] -> Either String PcbnewItem
 asPcbnewFpText (t:s:a:xs) = interpretType
     where
         interpretType = case t of
-            (Atom "reference") ->
+            (Atom pos "reference") ->
                 interpretString (defaultPcbnewFpText {fpTextType = FpTextReference})
-            (Atom "value")     ->
+            (Atom pos "value")     ->
                 interpretString (defaultPcbnewFpText {fpTextType = FpTextValue})
-            (Atom "user")     ->
+            (Atom pos "user")     ->
                 interpretString (defaultPcbnewFpText {fpTextType = FpTextUser})
             _           -> expecting "'reference', 'value' or 'user'" t
         interpretString fp_text = case s of
-            (Atom string) -> interpretAt fp_text {fpTextStr = string}
+            (Atom pos string) -> interpretAt fp_text {fpTextStr = string}
             _           -> expecting "string" s
         interpretAt fp_text = case fromSExpr a of
             Left err -> Left ('\t':err)
@@ -223,18 +224,18 @@ asPcbnewPad :: [SExpr] -> Either String PcbnewItem
 asPcbnewPad (n:t:s:xs) = interpretNumber
     where
         interpretNumber = case n of
-            (Atom num) -> interpretType defaultPcbnewPad {padNumber = num}
+            (Atom pos num) -> interpretType defaultPcbnewPad {padNumber = num}
             _ -> expecting "string designating pad number" n
         interpretType :: PcbnewItem -> Either String PcbnewItem
         interpretType pad = case t of
-            (Atom str) -> case strToPadType str of
+            (Atom pos str) -> case strToPadType str of
                     Just d  -> interpretShape pad {padType = d}
                     Nothing ->
                         expecting "pad type (e.g. 'smd')" t
             _ -> expecting "pad type string (e.g. 'smd')" t
         interpretShape :: PcbnewItem -> Either String PcbnewItem
         interpretShape pad = case s of
-            (Atom str) -> case strToPadShape str of
+            (Atom pos str) -> case strToPadShape str of
                     Just d  -> interpretRest xs pad {padShape = d}
                     Nothing ->
                         expecting "pad shape (e.g. 'circle')" s
@@ -278,19 +279,19 @@ asPcbnewLayer [sx] = onePcbnewLayer sx
 asPcbnewLayer x    = expecting' "only one layer name" x
 
 onePcbnewLayer :: SExpr -> Either String PcbnewAttribute
-onePcbnewLayer (Atom n) = case strToLayer n of
+onePcbnewLayer (Atom pos n) = case strToLayer n of
     Just l  -> Right $ PcbnewLayer l
     Nothing -> Left ("-> Unknown layer name: " ++ n)
 onePcbnewLayer x = expecting "layer name" x
 
 asPcbnewAt :: [SExpr] -> Either String PcbnewAttribute
-asPcbnewAt sx@(Atom x:[Atom y]) = case readXy x y of
+asPcbnewAt sx@(Atom posX x:[Atom posY y]) = case readXy x y of
     Just xy -> Right $ PcbnewAt $ defaultPcbnewAtT {pcbnewAtPoint = xy}
     Nothing -> expecting' "x y coordinates" sx
-asPcbnewAt sx@(Atom x:Atom y:[Atom o]) = case readXyz x y o of
+asPcbnewAt sx@(Atom posX x:Atom posY y:[Atom posO o]) = case readXyz x y o of
     Just (x', y', o') -> Right $ PcbnewAt $ PcbnewAtT (x',y') o'
     Nothing -> expecting' "x y coordinates and orientation" sx
-asPcbnewAt l@[List _] = asXyz PcbnewModelAt l
+asPcbnewAt l@[List pos _] = asXyz PcbnewModelAt l
 asPcbnewAt x =
     expecting' "x y coordinates and orientation" x
 
@@ -337,7 +338,7 @@ asPcbnewFont xs = interpretRest xs defaultPcbnewFont
             Right _ -> expecting "size, thickness or 'italic'" sx
 
 asXy :: ((Double, Double) -> a) -> [SExpr] -> Either String a
-asXy constructor sx@[Atom x, Atom y] = case readXy x y of
+asXy constructor sx@[Atom posX x, Atom posY y] = case readXy x y of
    Just xy -> Right $ constructor xy
    Nothing -> expecting' "two floats (e.g. 1.0 1.0)" sx
 asXy _ x = expecting' "two floats (e.g. 1.0 1.0)" x
@@ -351,7 +352,7 @@ asPcbnewPts = fmap PcbnewPts . foldr interpretXys (Right [])
                         Right _ -> expecting "'xy' (e.g. '(xy 1.0 1.0)')" sx
 
 asString :: (String -> PcbnewAttribute) -> [SExpr] -> Either String PcbnewAttribute
-asString pcbnew [Atom s] =  Right $ pcbnew s
+asString pcbnew [Atom pos s] =  Right $ pcbnew s
 asString _ x = expecting' "string" x
 
 asPcbnewLayers :: [SExpr] -> Either String PcbnewAttribute
@@ -362,13 +363,13 @@ asPcbnewLayers xs = let layers = map onePcbnewLayer xs in case lefts layers of
                     ++ unlines (map ("\t\t"++) (lefts layers))
 
 asDouble :: (Double -> PcbnewAttribute) -> [SExpr] -> Either String PcbnewAttribute
-asDouble constructor [sx@(Atom d)] = case readMaybe d of
+asDouble constructor [sx@(Atom pos d)] = case readMaybe d of
    Just d' -> Right $ constructor d'
    Nothing -> expecting "one float (e.g. '1.0')" sx
 asDouble _ x = expecting' "one float (e.g. '1.0')" x
 
 asInt :: (Int -> PcbnewAttribute) -> [SExpr] -> Either String PcbnewAttribute
-asInt constructor [sx@(Atom i)] = case readMaybe i of
+asInt constructor [sx@(Atom pos i)] = case readMaybe i of
    Just i' -> Right $ constructor i'
    Nothing -> expecting "one int (e.g. '1')" sx
 asInt _ x = expecting' "one int (e.g. '1')" x
@@ -378,13 +379,13 @@ asPcbnewDrill xs = interpretRest xs defaultPcbnewDrillT
     where
         interpretRest [] drill = Right $ PcbnewDrill drill
         interpretRest (sx:sxs) drill = case sx of
-            Atom "oval"  -> interpretRest sxs drill {pcbnewDrillOval = True}
-            (List _) -> case fromSExpr sx of
+            Atom pos "oval"  -> interpretRest sxs drill {pcbnewDrillOval = True}
+            (List pos _) -> case fromSExpr sx of
                 Left err -> Left ('\t':err)
                 Right (PcbnewExprAttribute (PcbnewOffset xy))
                     -> interpretRest sxs drill {pcbnewDrillOffset = Just xy}
                 Right _ -> expecting "offset or nothing" sx
-            Atom d  -> case readMaybe d of
+            Atom pos d  -> case readMaybe d of
                 Just d' -> if isNothing (pcbnewDrillSize drill)
                            then interpretRest sxs drill
                                 { pcbnewDrillSize = Just (d',d') }
@@ -396,20 +397,20 @@ asPcbnewDrill xs = interpretRest xs defaultPcbnewDrillT
             _ -> expecting "float, 'oval' or offset" sx
 
 asPcbnewXyz :: [SExpr] -> Either String PcbnewAttribute
-asPcbnewXyz sx@(Atom x:Atom y:[Atom z]) = case readXyz x y z of
+asPcbnewXyz sx@(Atom posX x:Atom posY y:[Atom posZ z]) = case readXyz x y z of
     Just xyz -> Right $ PcbnewXyz xyz
     Nothing -> expecting' "three floats" sx
 asPcbnewXyz x = expecting' "three floats" x
 
 asXyz :: (PcbnewAttribute -> a) -> [SExpr] -> Either String a
-asXyz constructor [l@(List _)] = case fromSExpr l of
+asXyz constructor [l@(List pos _)] = case fromSExpr l of
     Left err -> Left ('\t':err)
     Right (PcbnewExprAttribute xyz) -> Right $ constructor xyz
     Right _ -> expecting "xyz (e.g. '(xyz 1 1 1)')" l
 asXyz _ x = expecting' "xyz (e.g. '(xyz 1 1 1)')" x
 
 asPcbnewModel :: [SExpr] -> Either String PcbnewAttribute
-asPcbnewModel (Atom p:xs) = interpretRest xs defaultPcbnewModel {pcbnewModelPath = p}
+asPcbnewModel (Atom pos p:xs) = interpretRest xs defaultPcbnewModel {pcbnewModelPath = p}
     where
         interpretRest [] model = Right model
         interpretRest (sx:sxs) model = case fromSExpr sx of
@@ -437,7 +438,7 @@ asPcbnewJustifyT sx = case lefts js of
    where js = fmap oneJustifyT sx
 
 oneJustifyT :: SExpr -> Either String PcbnewJustifyT
-oneJustifyT sx@(Atom s) = case strToJustify s of
+oneJustifyT sx@(Atom pos s) = case strToJustify s of
    Just j -> Right j
    Nothing -> expecting justifyOneOf sx
 oneJustifyT x = expecting justifyOneOf x
@@ -445,8 +446,8 @@ oneJustifyT x = expecting justifyOneOf x
 
 expecting :: String -> SExpr -> Either String a
 expecting x y =
-    Left $ "-> Expecting " ++ x ++ " but got " ++
-        nothing_or (strip_brackets (write y)) ++ " instead"
+    Left $ "Expecting " ++ x ++ " but got " ++
+        nothing_or (strip_brackets (write y)) ++ " instead in " ++ pos
     where
         nothing_or y' = case y' of
             "" -> "nothing"
@@ -454,6 +455,7 @@ expecting x y =
         strip_brackets y' = case head y' of
                 '(' -> tail . init $ y'
                 _   -> y'
+        pos = show (getPos y)
 
 expecting' :: String -> [SExpr] -> Either String a
-expecting' x y = expecting x $ List y
+expecting' x y = expecting x $ List (newPos "" 0 0) y

--- a/Data/Kicad/PcbnewExpr/PcbnewExpr.hs
+++ b/Data/Kicad/PcbnewExpr/PcbnewExpr.hs
@@ -89,7 +89,7 @@ data PcbnewModule = PcbnewModule { pcbnewModuleName  :: String
 instance SExpressable PcbnewModule where
     toSExpr (PcbnewModule name l attrs items) =
         List $ [ Atom "module"
-               , atomStr name
+               , Atom name
                , toSExpr (PcbnewLayer l)
                ] ++ map toSExpr attrs
                ++ map toSExpr items
@@ -413,7 +413,7 @@ instance SExpressable PcbnewAttribute where
         List $ [ Atom "at"
                , atomDbl x
                , atomDbl y
-               ] ++ [Atom o | o /= 0]
+               ] ++ [atomDbl o | o /= 0]
     toSExpr (PcbnewLayers ls) =
         List (Atom "layers" : map (Atom . layerToStr) ls)
     toSExpr (PcbnewFont s t i) =
@@ -423,7 +423,7 @@ instance SExpressable PcbnewAttribute where
     toSExpr (PcbnewPts xys) =
         List $ Atom "pts" : map (toSExpr . PcbnewXy) xys
     toSExpr (PcbnewModel p a s r) =
-        List [Atom "model"
+        List [ Atom "model"
              , Atom p
              , toSExpr (PcbnewModelAt     (PcbnewXyz a))
              , toSExpr (PcbnewModelScale  (PcbnewXyz s))
@@ -479,13 +479,13 @@ instance SExpressable PcbnewAttribute where
 atomDbl = Atom . show
 
 toSxD :: String -> Double -> SExpr
-toSxD kw d = List [Atom kw, Atom d]
+toSxD kw d = List [Atom kw, atomDbl d]
 
 toSxDD :: String -> V2Double -> SExpr
 toSxDD kw (x,y) = List [Atom kw, atomDbl x, atomDbl y]
 
 toSxStr :: String -> String -> SExpr
-toSxStr kw s = List [Atom kw, atomStr s]
+toSxStr kw s = List [Atom kw, Atom s]
 
 instance AEq PcbnewAttribute where
     (PcbnewAt                x) ~== (PcbnewAt                y) = x ~== y

--- a/Data/Kicad/PcbnewExpr/PcbnewExpr.hs
+++ b/Data/Kicad/PcbnewExpr/PcbnewExpr.hs
@@ -88,8 +88,8 @@ data PcbnewModule = PcbnewModule { pcbnewModuleName  :: String
 
 instance SExpressable PcbnewModule where
     toSExpr (PcbnewModule name l attrs items) =
-        List $ [ AtomKey KeyModule
-               , AtomStr name
+        List $ [ Atom "module"
+               , atomStr name
                , toSExpr (PcbnewLayer l)
                ] ++ map toSExpr attrs
                ++ map toSExpr items
@@ -185,32 +185,32 @@ itemHandle f item = setter `fmap` (f (headOr (0,0) (view itemPoints item)))
 
 instance SExpressable PcbnewItem where
     toSExpr (PcbnewFpText t s a l h si th i j) =
-        List $ [ AtomKey KeyFpText
-               , AtomStr $ fpTextTypeToStr t
-               , AtomStr s
+        List $ [ Atom "fp_text"
+               , Atom $ fpTextTypeToStr t
+               , Atom s
                , toSExpr (PcbnewAt a)
                , toSExpr (PcbnewLayer l)
                ]
-               ++ [AtomStr "hide" | h]
+               ++ [Atom "hide" | h]
                ++ [toSExpr $ PcbnewFpTextEffects $
                       [PcbnewFont si th i]
                       ++ if j == [] then [] else [PcbnewJustify j]]
     toSExpr (PcbnewFpLine s e l w) =
-        List [ AtomKey KeyFpLine
+        List [ Atom "fp_line"
              , toSExpr (PcbnewStart s)
              , toSExpr (PcbnewEnd   e)
              , toSExpr (PcbnewLayer l)
              , toSExpr (PcbnewWidth w)
              ]
     toSExpr (PcbnewFpCircle s e l w) =
-        List [ AtomKey KeyFpCircle
+        List [ Atom "fp_circle"
              , toSExpr (PcbnewCenter s)
              , toSExpr (PcbnewEnd    e)
              , toSExpr (PcbnewLayer  l)
              , toSExpr (PcbnewWidth  w)
              ]
     toSExpr (PcbnewFpArc s e a l w) =
-        List [ AtomKey KeyFpArc
+        List [ Atom "fp_arc"
              , toSExpr (PcbnewStart s)
              , toSExpr (PcbnewEnd   e)
              , toSExpr (PcbnewAngle a)
@@ -218,16 +218,16 @@ instance SExpressable PcbnewItem where
              , toSExpr (PcbnewWidth w)
              ]
     toSExpr (PcbnewFpPoly ps l w) =
-        List [ AtomKey KeyFpPoly
+        List [ Atom "fp_poly"
              , toSExpr (PcbnewPts ps)
              , toSExpr (PcbnewLayer l)
              , toSExpr (PcbnewWidth w)
              ]
     toSExpr (PcbnewPad n t s a si l attrs) =
-        List $ [ AtomKey KeyPad
-               , AtomStr n
-               , AtomStr $ fpPadTypeToStr t
-               , AtomStr $ fpPadShapeToStr s
+        List $ [ Atom "pad"
+               , Atom n
+               , Atom $ fpPadTypeToStr t
+               , Atom $ fpPadShapeToStr s
                , toSExpr $ PcbnewAt a
                , toSExpr $ PcbnewSize si
                , toSExpr $ PcbnewLayers l
@@ -406,83 +406,86 @@ data PcbnewAttribute = PcbnewLayer      PcbnewLayerT
 type PcbnewXyzT = (Double, Double, Double)
 
 instance SExpressable PcbnewAttribute where
-    toSExpr (PcbnewLayer l) = List [ AtomKey KeyLayer
-                                  , AtomStr $ layerToStr l
-                                  ]
+    toSExpr (PcbnewLayer l) = List [ Atom "layer"
+                                   , Atom $ layerToStr l
+                                   ]
     toSExpr (PcbnewAt (PcbnewAtT (x,y) o)) =
-        List $ [ AtomKey KeyAt
-               , AtomDbl x
-               , AtomDbl y
-               ] ++ [AtomDbl o | o /= 0]
+        List $ [ Atom "at"
+               , atomDbl x
+               , atomDbl y
+               ] ++ [Atom o | o /= 0]
     toSExpr (PcbnewLayers ls) =
-        List (AtomKey KeyLayers : map (AtomStr . layerToStr) ls)
+        List (Atom "layers" : map (Atom . layerToStr) ls)
     toSExpr (PcbnewFont s t i) =
-        List $ [ AtomKey KeyFont, toSExpr (PcbnewSize s)
+        List $ [ Atom "font", toSExpr (PcbnewSize s)
                , toSExpr (PcbnewThickness t)
-               ] ++ [AtomStr "italic" | i]
+               ] ++ [Atom "italic" | i]
     toSExpr (PcbnewPts xys) =
-        List $ AtomKey KeyPts : map (toSExpr . PcbnewXy) xys
+        List $ Atom "pts" : map (toSExpr . PcbnewXy) xys
     toSExpr (PcbnewModel p a s r) =
-        List [AtomKey KeyModel
-             , AtomStr p
+        List [Atom "model"
+             , Atom p
              , toSExpr (PcbnewModelAt     (PcbnewXyz a))
              , toSExpr (PcbnewModelScale  (PcbnewXyz s))
              , toSExpr (PcbnewModelRotate (PcbnewXyz r))
              ]
     toSExpr (PcbnewDrill (PcbnewDrillT s o off)) =
-        List $ [AtomKey KeyDrill]
-             ++ [AtomStr "oval" | o]
+        List $ [Atom "drill"]
+             ++ [Atom "oval" | o]
              ++ (if o && isJust s
-                then [AtomDbl (fst (fromJust s)), AtomDbl (snd (fromJust s))]
-                else [AtomDbl (fst (fromJust s)) | isJust s])
+                then [atomDbl (fst (fromJust s)), atomDbl (snd (fromJust s))]
+                else [atomDbl (fst (fromJust s)) | isJust s])
              ++ [toSExpr (PcbnewOffset (fromJust off)) | isJust off]
     toSExpr (PcbnewXyz (x,y,z)) =
-        List [AtomKey KeyXyz, AtomDbl x, AtomDbl y, AtomDbl z]
-    toSExpr (PcbnewFpTextEffects l)  = List $ [AtomKey KeyEffects] ++ fmap toSExpr l
-    toSExpr (PcbnewFpTextType t)     = AtomStr $ fpTextTypeToStr t
-    toSExpr (PcbnewModelAt     xyz)  = List [AtomKey KeyAt    , toSExpr xyz]
-    toSExpr (PcbnewModelScale  xyz)  = List [AtomKey KeyScale , toSExpr xyz]
-    toSExpr (PcbnewModelRotate xyz)  = List [AtomKey KeyRotate, toSExpr xyz]
-    toSExpr (PcbnewClearance   d) = toSxD KeyClearance              d
-    toSExpr (PcbnewSolderPasteRatio d) = toSxD KeySolderPasteRatio  d
-    toSExpr (PcbnewMaskMargin  d) = toSxD KeySolderMaskMargin       d
-    toSExpr (PcbnewPasteMargin d) = toSxD KeySolderPasteMargin      d
-    toSExpr (PcbnewPasteMarginRatio d) = toSxD KeySolderPasteMarginRatio d
-    toSExpr (PcbnewRoundrectRratio  d) = toSxD KeyRoundrectRratio d
-    toSExpr (PcbnewThickness   d) = toSxD KeyThickness      d
-    toSExpr (PcbnewWidth       d) = toSxD KeyWidth          d
-    toSExpr (PcbnewAngle       d) = toSxD KeyAngle          d
-    toSExpr (PcbnewThermalWidth d) = toSxD KeyThermalWidth  d
-    toSExpr (PcbnewThermalGap   d) = toSxD KeyThermalGap    d
-    toSExpr (PcbnewSize      xy)  = toSxDD KeySize      xy
-    toSExpr (PcbnewStart     xy)  = toSxDD KeyStart     xy
-    toSExpr (PcbnewCenter    xy)  = toSxDD KeyCenter    xy
-    toSExpr (PcbnewRectDelta xy)  = toSxDD KeyRectDelta xy
-    toSExpr (PcbnewEnd       xy)  = toSxDD KeyEnd       xy
-    toSExpr (PcbnewXy        xy)  = toSxDD KeyXy        xy
-    toSExpr (PcbnewOffset    xy)  = toSxDD KeyOffset    xy
-    toSExpr (PcbnewTedit s)       = toSxStr KeyTedit s
-    toSExpr (PcbnewDescr s)       = toSxStr KeyDescr s
-    toSExpr (PcbnewTags  s)       = toSxStr KeyTags  s
-    toSExpr (PcbnewPath  s)       = toSxStr KeyPath  s
-    toSExpr (PcbnewAttr  s)       = toSxStr KeyAttr  s
-    toSExpr PcbnewItalic = AtomStr "italic"
-    toSExpr PcbnewHide   = AtomStr "hide"
-    toSExpr PcbnewPlaced = AtomStr "placed"
-    toSExpr PcbnewLocked = AtomStr "locked"
-    toSExpr (PcbnewAutoplaceCost90  i) = toSxD KeyAutoplaceCost90  (fromIntegral i)
-    toSExpr (PcbnewAutoplaceCost180 i) = toSxD KeyAutoplaceCost180 (fromIntegral i)
-    toSExpr (PcbnewZoneConnect      i) = toSxD KeyZoneConnect      (fromIntegral i)
-    toSExpr (PcbnewJustify         js) = List $ AtomKey KeyJustify:map (AtomStr . justifyToString) js
+        List [Atom "xyz", atomDbl x, atomDbl y, atomDbl z]
+    toSExpr (PcbnewFpTextEffects l)  = List $ [Atom "effects"] ++ fmap toSExpr l
+    toSExpr (PcbnewFpTextType t)     = Atom $ fpTextTypeToStr t
+    toSExpr (PcbnewModelAt     xyz)  = List [Atom "at"    , toSExpr xyz]
+    toSExpr (PcbnewModelScale  xyz)  = List [Atom "scale" , toSExpr xyz]
+    toSExpr (PcbnewModelRotate xyz)  = List [Atom "rotate", toSExpr xyz]
+    toSExpr (PcbnewClearance   d)      = toSxD "clearance"                 d
+    toSExpr (PcbnewSolderPasteRatio d) = toSxD "solder_paste_ratio"        d
+    toSExpr (PcbnewMaskMargin  d)      = toSxD "solder_mask_margin"        d
+    toSExpr (PcbnewPasteMargin d)      = toSxD "solder_paste_margin"       d
+    toSExpr (PcbnewPasteMarginRatio d) = toSxD "solder_paste_margin_ratio" d
+    toSExpr (PcbnewRoundrectRratio  d) = toSxD "roundrect_rratio"          d
+    toSExpr (PcbnewThickness   d)      = toSxD "thickness"                 d
+    toSExpr (PcbnewWidth       d)      = toSxD "width"                     d
+    toSExpr (PcbnewAngle       d)      = toSxD "angle"                     d
+    toSExpr (PcbnewThermalWidth d)     = toSxD "thermal_width"             d
+    toSExpr (PcbnewThermalGap   d)     = toSxD "key_thermal_gap"           d
+    toSExpr (PcbnewSize      xy)       = toSxDD "size"       xy
+    toSExpr (PcbnewStart     xy)       = toSxDD "start"      xy
+    toSExpr (PcbnewCenter    xy)       = toSxDD "center"     xy
+    toSExpr (PcbnewRectDelta xy)       = toSxDD "rect_delta" xy
+    toSExpr (PcbnewEnd       xy)       = toSxDD "end"        xy
+    toSExpr (PcbnewXy        xy)       = toSxDD "xy"         xy
+    toSExpr (PcbnewOffset    xy)       = toSxDD "offset"     xy
+    toSExpr (PcbnewTedit s)            = toSxStr "tedit" s
+    toSExpr (PcbnewDescr s)            = toSxStr "descr" s
+    toSExpr (PcbnewTags  s)            = toSxStr "tags"  s
+    toSExpr (PcbnewPath  s)            = toSxStr "path"  s
+    toSExpr (PcbnewAttr  s)            = toSxStr "attr"  s
+    toSExpr PcbnewItalic               = Atom "italic"
+    toSExpr PcbnewHide                 = Atom "hide"
+    toSExpr PcbnewPlaced               = Atom "placed"
+    toSExpr PcbnewLocked               = Atom "locked"
+    toSExpr (PcbnewAutoplaceCost90  i) = toSxD "autoplace_cost90"  (fromIntegral i)
+    toSExpr (PcbnewAutoplaceCost180 i) = toSxD "autoplace_cost180" (fromIntegral i)
+    toSExpr (PcbnewZoneConnect      i) = toSxD "zone_connect"      (fromIntegral i)
+    toSExpr (PcbnewJustify         js) = List $ (Atom "justify"):map (Atom . justifyToString) js
 
-toSxD :: Keyword -> Double -> SExpr
-toSxD  kw d = List [AtomKey kw, AtomDbl d]
 
-toSxDD :: Keyword -> V2Double -> SExpr
-toSxDD kw (x,y) = List [AtomKey kw, AtomDbl x, AtomDbl y]
+atomDbl = Atom . show
 
-toSxStr :: Keyword -> String -> SExpr
-toSxStr kw s = List [AtomKey kw, AtomStr s]
+toSxD :: String -> Double -> SExpr
+toSxD kw d = List [Atom kw, Atom d]
+
+toSxDD :: String -> V2Double -> SExpr
+toSxDD kw (x,y) = List [Atom kw, atomDbl x, atomDbl y]
+
+toSxStr :: String -> String -> SExpr
+toSxStr kw s = List [Atom kw, atomStr s]
 
 instance AEq PcbnewAttribute where
     (PcbnewAt                x) ~== (PcbnewAt                y) = x ~== y

--- a/Data/Kicad/PcbnewExpr/PcbnewExpr.hs
+++ b/Data/Kicad/PcbnewExpr/PcbnewExpr.hs
@@ -453,7 +453,7 @@ instance SExpressable PcbnewAttribute where
     toSExpr (PcbnewWidth       d)      = toSxD "width"                     d
     toSExpr (PcbnewAngle       d)      = toSxD "angle"                     d
     toSExpr (PcbnewThermalWidth d)     = toSxD "thermal_width"             d
-    toSExpr (PcbnewThermalGap   d)     = toSxD "key_thermal_gap"           d
+    toSExpr (PcbnewThermalGap   d)     = toSxD "thermal_gap"               d
     toSExpr (PcbnewSize      xy)       = toSxDD "size"       xy
     toSExpr (PcbnewStart     xy)       = toSxDD "start"      xy
     toSExpr (PcbnewCenter    xy)       = toSxDD "center"     xy
@@ -470,10 +470,14 @@ instance SExpressable PcbnewAttribute where
     toSExpr PcbnewHide                 = Atom "hide"
     toSExpr PcbnewPlaced               = Atom "placed"
     toSExpr PcbnewLocked               = Atom "locked"
-    toSExpr (PcbnewAutoplaceCost90  i) = toSxD "autoplace_cost90"  (fromIntegral i)
-    toSExpr (PcbnewAutoplaceCost180 i) = toSxD "autoplace_cost180" (fromIntegral i)
-    toSExpr (PcbnewZoneConnect      i) = toSxD "zone_connect"      (fromIntegral i)
-    toSExpr (PcbnewJustify         js) = List $ (Atom "justify"):map (Atom . justifyToString) js
+    toSExpr (PcbnewAutoplaceCost90  i) =
+        List [Atom "autoplace_cost90"  , Atom (show i)]
+    toSExpr (PcbnewAutoplaceCost180 i) =
+        List [Atom "autoplace_cost180" , Atom (show i)]
+    toSExpr (PcbnewZoneConnect      i) =
+        List [Atom "zone_connect"      , Atom (show i)]
+    toSExpr (PcbnewJustify         js) =
+        List $ (Atom "justify"):map (Atom . justifyToString) js
 
 
 atomDbl = Atom . show

--- a/Data/Kicad/SExpr.hs
+++ b/Data/Kicad/SExpr.hs
@@ -10,6 +10,7 @@ module Data.Kicad.SExpr
 , write
 -- * Parsing
 , parse
+, getPos
 )
 where
 import Data.Kicad.SExpr.SExpr

--- a/Data/Kicad/SExpr.hs
+++ b/Data/Kicad/SExpr.hs
@@ -4,12 +4,10 @@ module Data.Kicad.SExpr
 (
 -- * Types
   SExpr(..)
-, Keyword(..)
 , SExpressable(..)
 -- * Writing
 , pretty
 , write
-, writeKeyword
 -- * Parsing
 , parse
 )

--- a/Data/Kicad/SExpr.hs
+++ b/Data/Kicad/SExpr.hs
@@ -10,6 +10,7 @@ module Data.Kicad.SExpr
 , write
 -- * Parsing
 , parse
+, parseWithFilename
 , getPos
 )
 where

--- a/Data/Kicad/SExpr/Parse.hs
+++ b/Data/Kicad/SExpr/Parse.hs
@@ -44,10 +44,12 @@ parseList = do
     spaces
     return $ List list
 
+
 parseExpr :: Parser SExpr
 parseExpr =  try parseString
          <|> try parseListOrComment
          <?> "a double, string or s-expression"
+
 
 parseString :: Parser SExpr
 parseString = liftM Atom (parseQuotedString <|> parseUnquotedString <?> "string")
@@ -57,8 +59,8 @@ parseString = liftM Atom (parseQuotedString <|> parseUnquotedString <?> "string"
                 x <- many (noneOf "\\\"" <|> (char '\\' >> anyChar))
                 char '"'
                 return x
-            parseUnquotedString = many1 (noneOf "\" ()\r\n")
+            parseUnquotedString = many1 (noneOf " ()\r\n")
 
-spaces1 = skipMany1 spaceChar
+
 spaces = skipMany spaceChar
 spaceChar = oneOf "\r\n "

--- a/Data/Kicad/SExpr/Parse.hs
+++ b/Data/Kicad/SExpr/Parse.hs
@@ -2,6 +2,7 @@
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 module Data.Kicad.SExpr.Parse
 ( parse
+, parseWithFilename
 )
 where
 import Text.ParserCombinators.Parsec hiding (spaces, parse)
@@ -14,9 +15,14 @@ import Data.Kicad.SExpr.SExpr
 
 {-| Parse a 'String' as a 'SExpr' or return an error. -}
 parse :: String -> Either String SExpr
-parse input = case Parsec.parse parseListOrComment "SExpr" input of
-    Left err -> Left $ "Parse Error: " ++ show err
-    Right val -> Right val
+parse = parseWithFilename ""
+
+{-| Parse a 'String' as a 'SExpr' giving a filename to use in the source code location -}
+parseWithFilename :: String -> String -> Either String SExpr
+parseWithFilename filename input =
+    case Parsec.parse parseListOrComment filename input of
+        Left err -> Left $ "Parse Error: " ++ show err
+        Right val -> Right val
 
 
 parseListOrComment :: Parser SExpr

--- a/Data/Kicad/SExpr/Parse.hs
+++ b/Data/Kicad/SExpr/Parse.hs
@@ -6,7 +6,6 @@ module Data.Kicad.SExpr.Parse
 where
 import Text.ParserCombinators.Parsec hiding (spaces, parse)
 import qualified Text.ParserCombinators.Parsec as Parsec (parse)
-import Text.ParserCombinators.Parsec.Number
 import Text.Parsec.Char (endOfLine)
 import Control.Monad
 
@@ -40,38 +39,38 @@ parseList :: Parser SExpr
 parseList = do
     char '('
     spaces
-    first <- parseKeyword
+    first <- parseString
     spaces
     rest <- let parseRest = try parseAtom `sepEndBy` spaces in case first of
-        AtomKey KeyFpText -> do t <- parseString
-                                  <?> "string designating type e.g. 'user'"
-                                spaces1
-                                s <- parseString
-                                spaces
-                                r <- parseRest
-                                return (t:s:r)
-        AtomKey KeyModule -> do t <- parseString
-                                spaces
-                                r <- parseRest
-                                return (t:r)
-        AtomKey KeyTedit  -> do s <- parseString
-                                spaces
-                                return [s]
-        AtomKey KeyDescr  -> do s <- parseString
-                                spaces
-                                return [s]
-        AtomKey KeyTags   -> do s <- parseString
-                                spaces
-                                return [s]
-        AtomKey KeyPad    -> do n <- parseString
-                                spaces1
-                                t <- parseString
-                                  <?> "string designating type e.g. 'smd'"
-                                spaces1
-                                s <- parseString
-                                spaces
-                                r <- parseRest
-                                return (n:t:s:r)
+        Atom "fp_text" -> do t <- parseString
+                               <?> "string designating type e.g. 'user'"
+                             spaces1
+                             s <- parseString
+                             spaces
+                             r <- parseRest
+                             return (t:s:r)
+        Atom "module" -> do t <- parseString
+                            spaces
+                            r <- parseRest
+                            return (t:r)
+        Atom "tedit"  -> do s <- parseString
+                            spaces
+                            return [s]
+        Atom "descr"  -> do s <- parseString
+                            spaces
+                            return [s]
+        Atom "tags"   -> do s <- parseString
+                            spaces
+                            return [s]
+        Atom "pad"    -> do n <- parseString
+                            spaces1
+                            t <- parseString
+                              <?> "string designating type e.g. 'smd'"
+                            spaces1
+                            s <- parseString
+                            spaces
+                            r <- parseRest
+                            return (n:t:s:r)
         _                 -> parseRest
     spaces
     char ')'
@@ -79,16 +78,9 @@ parseList = do
     return $ List (first:rest)
 
 parseAtom :: Parser SExpr
-parseAtom =  try parseDouble
-         <|> try parseString
+parseAtom =  try parseString
          <|> try parseListOrComment
          <?> "a double, string or s-expression"
-
-parseOneKeyword :: String -> Parser SExpr
-parseOneKeyword kw = try $ string kw >> return (Atom kw)
-
-parseKeyword :: Parser SExpr
-parseKeyword = choice (map parseOneKeyword [minBound..maxBound]) <?> "keyword"
 
 parseString :: Parser SExpr
 parseString = liftM Atom (parseQuotedString <|> parseUnquotedString <?> "string")
@@ -99,15 +91,6 @@ parseString = liftM Atom (parseQuotedString <|> parseUnquotedString <?> "string"
                 char '"'
                 return x
             parseUnquotedString = many1 (noneOf "\" ()\r\n")
-
-parseDouble :: Parser SExpr
-parseDouble = do
-    negate_or_id <- sign
-    -- the Bool in floating3 is requireDigit which affects whether many (False,
-    -- 0 or more) or many1 (True, 1 or more) is used
-    x <- floating3 True
-    lookAhead (char ')' <|> spaceChar)
-    return $ AtomDbl $ negate_or_id x
 
 spaces1 = skipMany1 spaceChar
 spaces = skipMany spaceChar

--- a/Data/Kicad/SExpr/Parse.hs
+++ b/Data/Kicad/SExpr/Parse.hs
@@ -11,7 +11,6 @@ import Text.Parsec.Char (endOfLine)
 import Control.Monad
 
 import Data.Kicad.SExpr.SExpr
-import Data.Kicad.SExpr.Write (writeKeyword)
 
 {-| Parse a 'String' as a 'SExpr' or return an error. -}
 parse :: String -> Either String SExpr
@@ -85,14 +84,14 @@ parseAtom =  try parseDouble
          <|> try parseListOrComment
          <?> "a double, string or s-expression"
 
-parseOneKeyword :: Keyword -> Parser SExpr
-parseOneKeyword kw = try $ string (writeKeyword kw) >> return (AtomKey kw)
+parseOneKeyword :: String -> Parser SExpr
+parseOneKeyword kw = try $ string kw >> return (Atom kw)
 
 parseKeyword :: Parser SExpr
 parseKeyword = choice (map parseOneKeyword [minBound..maxBound]) <?> "keyword"
 
 parseString :: Parser SExpr
-parseString = liftM AtomStr (parseQuotedString <|> parseUnquotedString <?> "string")
+parseString = liftM Atom (parseQuotedString <|> parseUnquotedString <?> "string")
         where
             parseQuotedString  = do
                 char '"'

--- a/Data/Kicad/SExpr/Parse.hs
+++ b/Data/Kicad/SExpr/Parse.hs
@@ -39,46 +39,13 @@ parseList :: Parser SExpr
 parseList = do
     char '('
     spaces
-    first <- parseString
-    spaces
-    rest <- let parseRest = try parseAtom `sepEndBy` spaces in case first of
-        Atom "fp_text" -> do t <- parseString
-                               <?> "string designating type e.g. 'user'"
-                             spaces1
-                             s <- parseString
-                             spaces
-                             r <- parseRest
-                             return (t:s:r)
-        Atom "module" -> do t <- parseString
-                            spaces
-                            r <- parseRest
-                            return (t:r)
-        Atom "tedit"  -> do s <- parseString
-                            spaces
-                            return [s]
-        Atom "descr"  -> do s <- parseString
-                            spaces
-                            return [s]
-        Atom "tags"   -> do s <- parseString
-                            spaces
-                            return [s]
-        Atom "pad"    -> do n <- parseString
-                            spaces1
-                            t <- parseString
-                              <?> "string designating type e.g. 'smd'"
-                            spaces1
-                            s <- parseString
-                            spaces
-                            r <- parseRest
-                            return (n:t:s:r)
-        _                 -> parseRest
-    spaces
+    list <- try parseExpr `sepEndBy` spaces
     char ')'
     spaces
-    return $ List (first:rest)
+    return $ List list
 
-parseAtom :: Parser SExpr
-parseAtom =  try parseString
+parseExpr :: Parser SExpr
+parseExpr =  try parseString
          <|> try parseListOrComment
          <?> "a double, string or s-expression"
 

--- a/Data/Kicad/SExpr/SExpr.hs
+++ b/Data/Kicad/SExpr/SExpr.hs
@@ -1,12 +1,20 @@
 module Data.Kicad.SExpr.SExpr
 ( SExpr(..)
 , SExpressable(..)
+, getPos
 )
 where
+import Text.Parsec (SourcePos)
 
-data SExpr = Atom String
-           | List [SExpr]
+data SExpr = Atom SourcePos String
+           | List SourcePos [SExpr]
     deriving (Show, Eq)
 
 class SExpressable a where
     toSExpr :: a -> SExpr
+
+{-| Get s-expression source code position (filename, line-number and
+ - column-number) -}
+getPos :: SExpr -> SourcePos
+getPos (Atom pos _) = pos
+getPos (List pos _) = pos

--- a/Data/Kicad/SExpr/SExpr.hs
+++ b/Data/Kicad/SExpr/SExpr.hs
@@ -1,67 +1,12 @@
 module Data.Kicad.SExpr.SExpr
 ( SExpr(..)
-, Keyword(..)
 , SExpressable(..)
 )
 where
 
-data SExpr = AtomKey Keyword
-           | AtomStr String
-           | AtomDbl Double
+data SExpr = Atom String
            | List [SExpr]
     deriving (Show, Eq)
-
-{- The keywords _must_ be "Key" ++ camel-case version of the ones in the
- - kicad_mod files as the parser and writer use the derived 'Show' instance.
- - The parser will also try them in the order they appear below so KeyAttr has
- - to appear before KeyAt for instance. -}
-data Keyword =
-               KeyAngle
-             | KeyAttr
-             | KeyAt
-             | KeyAutoplaceCost180
-             | KeyAutoplaceCost90
-             | KeyCenter
-             | KeyClearance
-             | KeyDescr
-             | KeyDrill
-             | KeyEffects
-             | KeyEnd
-             | KeyFont
-             | KeyFpArc
-             | KeyFpCircle
-             | KeyFpLine
-             | KeyFpPoly
-             | KeyFpText
-             | KeyJustify
-             | KeyLayers
-             | KeyLayer
-             | KeyModel
-             | KeyModule
-             | KeyOffset
-             | KeyPad
-             | KeyPath
-             | KeyPts
-             | KeyRectDelta
-             | KeyRotate
-             | KeyRoundrectRratio
-             | KeyScale
-             | KeySize
-             | KeySolderMaskMargin
-             | KeySolderPasteMarginRatio
-             | KeySolderPasteMargin
-             | KeySolderPasteRatio
-             | KeyStart
-             | KeyTags
-             | KeyTedit
-             | KeyThermalGap
-             | KeyThermalWidth
-             | KeyThickness
-             | KeyWidth
-             | KeyXyz
-             | KeyXy
-             | KeyZoneConnect
-    deriving (Show, Eq, Enum, Bounded)
 
 class SExpressable a where
     toSExpr :: a -> SExpr

--- a/Data/Kicad/SExpr/Write.hs
+++ b/Data/Kicad/SExpr/Write.hs
@@ -1,7 +1,6 @@
 module Data.Kicad.SExpr.Write
 ( pretty
 , write
-, writeKeyword
 )
 where
 import Data.Char (toLower, isLower, isNumber)
@@ -18,28 +17,10 @@ pretty atm = text $ write atm
 
 {-| Serialize an SExpr as a compact s-expression 'String'. -}
 write :: SExpr -> String
-write (AtomKey kw)  = writeKeyword kw
-write (AtomStr atm) |  (atm == "")
-                    || head atm `elem` '.':'-':['0'..'9']
-                    || foldr
-                        (\c z -> z || c `elem` ')':'(':'\\':'\"':['\0'..' '])
-                            False atm = show atm -- escaped string with quotes
-                    | otherwise       = atm
--- this should just be printf "%g" but that doesn't work as it should
-write (AtomDbl atm) = strip_zeros $ break (== '.') $ show atm
-    where strip_zeros (s1,s2) = s1 ++ dot_if_needed (reverse
-                                           $ dropWhile (=='0') $ reverse s2)
-          dot_if_needed s     = if s == "." then "" else s
+write (Atom atm) |  (atm == "")
+                     || head atm `elem` '.':'-':['0'..'9']
+                     || foldr
+                         (\c z -> z || c `elem` ')':'(':'\\':'\"':['\0'..' '])
+                             False atm = show atm -- escaped string with quotes
+                 | otherwise       = atm
 write (List    sxs) = "(" ++ unwords (map write sxs) ++ ")"
-
-{-| Write a 'Keyword' as a 'String'. Removes \"Key\" from the 'Show'
-   instance and converts the rest to underscore (e.g KeyFpTextType becomes
-   "fp_text_type"). -}
-writeKeyword :: Keyword -> String
-writeKeyword = intercalate "_" . splitCapWords . drop 3 . show
-    where
-        splitCapWords "" = []
-        splitCapWords (x:xs) =
-            let (word, rest) = span (\c -> isLower c || isNumber c) xs
-            in (toLower x : word) : splitCapWords rest
-

--- a/Data/Kicad/SExpr/Write.hs
+++ b/Data/Kicad/SExpr/Write.hs
@@ -11,16 +11,16 @@ import Data.Kicad.SExpr.SExpr
 
 {-| Pretty-print a 'SExpr' as a readable 'Doc'. -}
 pretty :: SExpr -> Doc
-pretty (List xs) = text "(" <> align (sep $ map pretty xs) <> text ")"
+pretty (List _ xs) = text "(" <> align (sep $ map pretty xs) <> text ")"
 pretty atm = text $ write atm
 
 
 {-| Serialize an SExpr as a compact s-expression 'String'. -}
 write :: SExpr -> String
-write (Atom atm) |  (atm == "")
-                     || head atm `elem` '.':'-':['0'..'9']
-                     || foldr
-                         (\c z -> z || c `elem` ')':'(':'\\':'\"':['\0'..' '])
-                             False atm = show atm -- escaped string with quotes
-                 | otherwise       = atm
-write (List    sxs) = "(" ++ unwords (map write sxs) ++ ")"
+write (Atom _ str) |  (str == "")
+                       || head str `elem` '.':'-':['0'..'9']
+                       || foldr
+                           (\c z -> z || c `elem` ')':'(':'\\':'\"':['\0'..' '])
+                               False str = show str -- escaped string with quotes
+                   | otherwise       = str
+write (List _ sxs) = "(" ++ unwords (map write sxs) ++ ")"

--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -63,7 +63,10 @@ test-suite kicad-data-quickcheck
     , lens-family >= 1.1 && <1.3
     , ieee754 >= 0.7.4 && <0.9
     , QuickCheck >= 2
+    , HUnit >= 1.5 && < 1.7
     , test-framework >= 0.8 && < 1
+    , test-framework-quickcheck2 >= 0.3 && < 0.4
+    , test-framework-hunit >= 0.3 && < 0.4
     , test-framework-quickcheck2 >= 0.3 && < 1
     , pretty-compact >= 1.0 && < 2
     , kicad-data

--- a/tests/Parse.hs
+++ b/tests/Parse.hs
@@ -14,7 +14,7 @@ parseAndDisplay :: [String] -> IO ()
 parseAndDisplay [] = return ()
 parseAndDisplay (f:fs) = do
             input <- readFile f
-            case PcbnewExpr.parse input of
-                Left err -> hPutStrLn stderr "FAILED:" >> hPutStrLn stderr f >> hPutStrLn stderr err >> exitFailure
+            case PcbnewExpr.parseWithFilename f input of
+                Left err -> hPutStrLn stderr err >> exitFailure
                 Right px -> print (PcbnewExpr.pretty px) >> parseAndDisplay fs
 

--- a/tests/SExpr.hs
+++ b/tests/SExpr.hs
@@ -52,17 +52,19 @@ deterministic1 sx = tracedPropEq t1 t2
 allowQuoteMarks1 :: IO ()
 allowQuoteMarks1 =
     let sx = parse "(x\")" in
-    if sx /= Right (List (newPos "SExpr" 1 1) [Atom (newPos "SExpr" 1 2) "x\""])
+    if sx /= Right (List (newPos "" 1 1) [Atom (newPos "" 1 2) "x\""])
     then assertFailure ("could not parse quote mark, got: " ++ show sx)
     else return ()
 
+
 allowQuoteMarks2 :: IO ()
 allowQuoteMarks2 =
-    let sx = parse "(xxxx\"yyyy yyyy\"xxxx)"
-        expected = Right $ List (newPos "SExpr" 1 1)
-            [ Atom (newPos "SExpr" 1 2)"xxxx\"yyyy"
-            , Atom (newPos "SExpr" 1 12)"yyyy\"xxxx"
-            ]
+    let f = "foo"
+        sx = parseWithFilename f "(xxxx\"yyyy yyyy\"xxxx)"
+        expected = Right $ List (newPos f 1 1)
+            [ Atom (newPos f 1 2)"xxxx\"yyyy"
+            , Atom (newPos f 1 12)"yyyy\"xxxx"
+            ] :: Either String SExpr
     in if sx /= expected
-       then assertFailure ("could not parse quote mark, got: " ++ show sx)
+       then assertFailure ("could not parse quote mark, got: " ++ show sx ++ "\n\texpecting: " ++ (show expected))
        else return ()

--- a/tests/SExpr.hs
+++ b/tests/SExpr.hs
@@ -7,14 +7,45 @@ import Test.Framework (Test)
 import Test.Framework.Providers.QuickCheck2
 import Test.QuickCheck
 import Control.Monad (liftM)
+import Data.Either (rights)
 
 import Utils
 
 import Data.Kicad.SExpr
 
 tests :: [Test]
-tests = [
+tests = [ testProperty "deterministic 1" deterministic1
+        , testProperty "deterministic 2" deterministic2
         ]
 
+
 instance Arbitrary SExpr where
-    arbitrary = undefined
+    arbitrary = sized arbitrarySExp
+
+
+-- so we don't create infinitely large s-expressions we keep reducing the size
+-- as we go deeper and return atoms when the size is 0
+arbitrarySExp :: Int -> Gen SExpr
+arbitrarySExp n | n > 0 =
+    oneof [ arbitraryAtom
+          , liftM List $ resize (n `div` 2) arbitrary
+          ]
+arbitrarySExp _ = arbitraryAtom
+
+
+arbitraryAtom :: Gen SExpr
+arbitraryAtom = liftM Atom genSafeString
+
+
+deterministic1 :: SExpr -> Bool
+deterministic1 sx = tracedPropEq t1 t2
+        where sx' = List [sx]
+              t1 = write sx'
+              t2 = either id write $ parse t1
+
+
+deterministic2 :: SExpr -> Bool
+deterministic2 sx = tracedPropEq t1 t2
+        where sx' = List [sx]
+              t1 = Right sx'
+              t2 = parse $ write $ head  $ rights [t1]

--- a/tests/SExpr.hs
+++ b/tests/SExpr.hs
@@ -13,29 +13,8 @@ import Utils
 import Data.Kicad.SExpr
 
 tests :: [Test]
-tests = [ testProperty "parse all keywords" parseAllKeywords
+tests = [
         ]
 
-parseAllKeywords :: Keyword -> Bool
-parseAllKeywords kw = tracedPropEq t1 t2
-    where t1 = parse ("(" ++  writeKeyword kw ++ ")")
-          t2 = parse $ either id write $ parse ("(" ++  writeKeyword kw ++ ")")
-
 instance Arbitrary SExpr where
-    arbitrary = oneof [ liftM AtomKey arbitrary
-                      , liftM AtomStr genSafeString
-                      , liftM AtomDbl arbitrary
-                      , do ls <- arbitrary
-                           kw <- elements specialKeywords
-                           return $ List $ [AtomKey kw, AtomStr "a", AtomStr "b", AtomStr "c"] ++ ls
-                      , do ls <- arbitrary
-                           kw <- arbitrary
-                           return $ List $ AtomKey kw : ls
-                      ]
-
-instance Arbitrary Keyword
-    where arbitrary = elements $ filter notSpecial [minBound .. maxBound]
-            where notSpecial x = x `notElem` specialKeywords
-
-specialKeywords :: [Keyword]
-specialKeywords = [KeyTags, KeyModule, KeyPad, KeyFpText, KeyDescr, KeyTedit]
+    arbitrary = undefined

--- a/tests/SExpr.hs
+++ b/tests/SExpr.hs
@@ -4,7 +4,9 @@ module SExpr
 )
 where
 import Test.Framework (Test)
-import Test.Framework.Providers.QuickCheck2
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Framework.Providers.HUnit  (testCase)
+import Test.HUnit (assertFailure)
 import Test.QuickCheck
 import Control.Monad (liftM)
 import Data.Either (rights)
@@ -16,6 +18,8 @@ import Data.Kicad.SExpr
 tests :: [Test]
 tests = [ testProperty "deterministic 1" deterministic1
         , testProperty "deterministic 2" deterministic2
+        , testCase "allows quote marks in unquoted strings" allowQuoteMarks1
+        , testCase "allows quote marks in unquoted strings 2" allowQuoteMarks2
         ]
 
 
@@ -49,3 +53,18 @@ deterministic2 sx = tracedPropEq t1 t2
         where sx' = List [sx]
               t1 = Right sx'
               t2 = parse $ write $ head  $ rights [t1]
+
+
+allowQuoteMarks1 :: IO ()
+allowQuoteMarks1 =
+    let sx = parse "(x\")" in
+    if sx /= Right (List [Atom "x\""])
+    then assertFailure ("could not parse quote mark, got: " ++ show sx)
+    else return ()
+
+allowQuoteMarks2 :: IO ()
+allowQuoteMarks2 =
+    let sx = parse "(xxxx\"yyyy yyyy\"xxxx)" in
+    if sx /= Right (List [Atom "xxxx\"yyyy", Atom "yyyy\"xxxx"])
+    then assertFailure ("could not parse quote mark, got: " ++ show sx)
+    else return ()


### PR DESCRIPTION
Adresses #6 and also keeps the line and column number within the `SExpr` data structure to let the Pcbnew parser report errors with a source location. 