### PR TITLE
Fix links to KiCad website, now https://kicad.org/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Haskell KiCad Data
 [![Build Status](https://travis-ci.org/monostable/haskell-kicad-data.svg?branch=master)](https://travis-ci.org/monostable/haskell-kicad-data)
 
-Parse and write [KiCad](http://kicad-pcb.org) data (currently .kicad_mod files only).
+Parse and write [KiCad](https://kicad.org/) data (currently .kicad_mod files only).
 
 This library is tested with QuickCheck to ensure it can parse whatever it outputs. 
 The parser is also fairly regularily checked against over 38,000 kicad_mod files currently part of [monostable/kicad_footprints](https://github.com/monostable/kicad_footprints). The resulting output of these parsed files is then checked with KiCad scripting to make sure they are still valid.

--- a/kicad-data.cabal
+++ b/kicad-data.cabal
@@ -13,7 +13,7 @@ build-type:    Simple
 extra-source-files: README.md
 cabal-version: >=1.10
 description:
-            Parse and write <http://kicad-pcb.org/ KiCad> data
+            Parse and write <https://kicad.org/ KiCad> data
             (currently @.kicad_mod@ files only).
 Extra-Source-Files: changelog.md
 


### PR DESCRIPTION
The old links to kicad dash pcb dot org are no longer considered valid.  This branch updates them to the new site, <https://kicad.org/>.

For more information, see [this post](https://forum.kicad.info/t/warning-avoid-all-links-to-kicad-pcb-org-use-kicad-org/31521).